### PR TITLE
Use the new-release task in the build-from-scratch pipeline and fix it to use a docker-registry secret

### DIFF
--- a/pipelines/01-new-release-task.yaml
+++ b/pipelines/01-new-release-task.yaml
@@ -18,7 +18,7 @@ spec:
       image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
       script: |
         oc adm release new \
-            --registry-config=$(workspaces.credentials.path)/auth.json \
+            --registry-config=$(workspaces.credentials.path)/.dockerconfigjson \
             --from-image-stream release \
             --insecure=true \
             --mirror $(params.release-mirror-location) \
@@ -26,5 +26,5 @@ spec:
             --name=$(params.release-image-name)
   workspaces:
     - name: credentials
-      description: The folder where we write the message to
+      description: The folder where the docker-registry secret is mounted
       mountPath: /credentials

--- a/pipelines/build-from-scratch.yaml
+++ b/pipelines/build-from-scratch.yaml
@@ -244,18 +244,15 @@ spec:
       runAfter:
       - batch-03
       taskRef:
-        name: openshift-client
-        kind: ClusterTask
+        name: new-release
+        kind: Task
       workspaces:
-      - name: manifest-dir
-        workspace: push-credentials
+        - workspace: push-credentials
+          name: credentials
       params:
-        - name: SCRIPT
-          value: |
-            oc adm release new \
-            --registry-config=$(workspaces.manifest-dir.path)/auth.json \
-            --from-image-stream release \
-            --insecure=true \
-            --mirror $(params.result-mirror-location) \
-            --to-image $(params.result-image) \
-            --name=$(params.result-image-name)
+        - name: release-mirror-location
+          value: $(params.result-mirror-location)
+        - name: release-image
+          value: $(params.result-image)
+        - name: release-image-name
+          value: $(params.result-image-name)


### PR DESCRIPTION
This PR is a minor fix to let the build-from-scratch pipeline use the new-release Task as aref and also let the user use a docker-registry secret instead of a custom one to map the pull secret json file.