### PR TITLE
Additional kustomization patch to replace cli images

### DIFF
--- a/buildconfigs/20-agent-installer-api-server.yaml
+++ b/buildconfigs/20-agent-installer-api-server.yaml
@@ -9,12 +9,7 @@ spec:
       uri: 'https://github.com/openshift/assisted-service'
       ref: release-4.12
     contextDir: .
-    images:
-      - from:
-          kind: ImageStreamTag
-          name: 'release:cli'
-        as:
-          - 'registry.ci.openshift.org/ocp/4.11:cli'
+    images: []
   strategy:
     type: Docker
     dockerStrategy:

--- a/buildconfigs/20-agent-installer-csr-approver.yaml
+++ b/buildconfigs/20-agent-installer-csr-approver.yaml
@@ -9,12 +9,7 @@ spec:
       uri: 'https://github.com/openshift/assisted-installer'
       ref: release-4.12
     contextDir: .
-    images:
-      - from:
-          kind: ImageStreamTag
-          name: 'release:cli'
-        as:
-          - 'registry.ci.openshift.org/ocp/4.11:cli'
+    images: []
   strategy:
     type: Docker
     dockerStrategy:

--- a/buildconfigs/20-ovn-kubernetes.yaml
+++ b/buildconfigs/20-ovn-kubernetes.yaml
@@ -12,11 +12,6 @@ spec:
     images:
       - from:
           kind: ImageStreamTag
-          name: 'release:cli'
-        as:
-          - 'registry.ci.openshift.org/ocp/4.12:cli'
-      - from:
-          kind: ImageStreamTag
           name: 'release:forked-dockerfiles'
         paths:
         - sourcePath: /code/ovn-kubernetes/Dockerfile.centos9

--- a/buildconfigs/kustomization.yaml
+++ b/buildconfigs/kustomization.yaml
@@ -24,6 +24,15 @@ patches:
               - 'registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.9'
               - 'registry.ci.openshift.org/ocp/builder:rhel-8-etcd-golang-1.16'
               - 'registry.ci.openshift.org/openshift/release:golang-1.17'
+      - op: add
+        path: "/spec/source/images/-"
+        value:
+          from:
+            kind: ImageStreamTag
+            name: 'release:cli'
+          as:
+            - 'registry.ci.openshift.org/ocp/4.11:cli'
+            - 'registry.ci.openshift.org/ocp/4.12:cli'
     target:
       kind: BuildConfig
       labelSelector: "builder-replacement!=skip"


### PR DESCRIPTION
The bump of the agent-installer base images needs the replacement of the 4.11 cli image to the 4.12 one: replacing them all with kustomize