### PR TITLE
Fixes for hyperkube (again)

### DIFF
--- a/buildconfigs/10-hyperkube.yaml
+++ b/buildconfigs/10-hyperkube.yaml
@@ -62,8 +62,9 @@ spec:
         - name: VERSIONS
           value: "kubernetes=1.25.0"
           # TODO ^^ dynamic handling from the pipeline
-        - name: ADDITIONAL_FILES_FROM_REPO_GLOB
-          value: "openshift-hack/images/hyperkube/*"
+          # TODO VV refactor me (see forked dockerfile)
+        - name: ADDITIONAL_BIN_FOLDER_FROM_REPO
+          value: "openshift-hack/images/hyperkube"
   output:
     to:
       kind: ImageStreamTag

--- a/forks/artifacts/Dockerfile.builder.centos9
+++ b/forks/artifacts/Dockerfile.builder.centos9
@@ -47,8 +47,9 @@ RUN mkdir -p "${RPMBUILD_DIR}"/{BUILD,SOURCES,SPECS,SRPMS,rpms}; \
         "${RPMBUILD_DIR}/SPECS/${SPEC_FILENAME}"; \
     done
 
-RUN  mkdir -p /tmp/additional_bins; if [ -n "${ADDITIONAL_FILES_FROM_REPO_GLOB}" ]; then \
-        cp "${ADDITIONAL_FILES_FROM_REPO_GLOB}" /tmp/additional_bins; fi
+# TODO refactor me. this is currently needed to copy the hyperkube and kubensenter scripts in the hyperkube image
+RUN  mkdir -p /tmp/additional_bins; if [ -n "${ADDITIONAL_BIN_FOLDER_FROM_REPO}" ]; then \
+        cp "${ADDITIONAL_BIN_FOLDER_FROM_REPO}/*" /tmp/additional_bins; fi
 
 FROM registry.ci.openshift.org/ocp/4.11:cli
 


### PR DESCRIPTION
- Changes ADDITIONAL_FILES_FROM_REPO_GLOB to ADDITIONAL_BIN_FOLDER_FROM_REPO (the glob expansions from variable don't work)
This is temporary until we can get a cycle to go through the generic rpm artifacts image again.