### PR TITLE
initial commit of okd release pipeline

### DIFF
--- a/pipelines/01-batch-build-task.yaml
+++ b/pipelines/01-batch-build-task.yaml
@@ -2,6 +2,7 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: batch-build
+  namespace: okd-team
 spec:
   params:
     - name: build_configs

--- a/pipelines/01-new-release-task.yaml
+++ b/pipelines/01-new-release-task.yaml
@@ -2,6 +2,7 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: new-release
+  namespace: okd-team
 spec:
   params:
     - name: release-mirror-location

--- a/pipelines/okd-release-pipeline.yaml
+++ b/pipelines/okd-release-pipeline.yaml
@@ -1,0 +1,104 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: okd-release-pipeline
+  namespace: okd-team
+spec:
+  params:
+    - description: The URL for the release controller to use
+      name: release-controller
+      type: string
+      default: "https://origin-release.ci.openshift.org"
+    - description: The release stream to use (e.g., 4.12.0-0.okd, 4.12.0-0.okd-scos)
+      name: release-stream
+      type: string
+    - description: The app.ci imagestream to use for tagging (e.g., release or release-scos)
+      name: release-imagestream
+      type: string
+  tasks:
+    - name: build-pipeline-worker-image
+      taskRef:
+        name: batch-build
+      params:
+        - name: build_configs
+          value:
+          - tekton-worker-image-build
+    - name: pick-release
+      taskRef:
+        name: pick-release
+      params:
+        - name: release-controller
+          value: $(params.release-controller)
+        - name: release-stream
+          value: $(params.release-stream)
+      runAfter:
+        - build-pipeline-worker-image
+    - name: verify-release
+      taskRef:
+        name: gpg-verify-release
+      params:
+        - name: release-digest
+          value: $(tasks.pick-release.results.release-digest)
+      runAfter:
+        - pick-release
+    - name: mirror
+      taskRef:
+        name: mirror-release
+      params:
+        - name: release-name
+          value: $(tasks.pick-release.results.release-name)
+        - name: release-pullspec
+          value: $(tasks.pick-release.results.release-pullspec)
+        - name: image-push-secret-name
+          value: okd-okd-robot-pull-secret
+        - name: content-mirror-pushspec
+          value: quay.io/okd/scos-content
+        - name: release-mirror-pushspec
+          value: "quay.io/okd/scos-release"
+        - name: gpg-secret-name
+          value: okd-private-key
+        - name: gpg-secret-key-name
+          value: private.key
+        - name: gpg-key-id
+          value: maintainers@okd.io
+      runAfter:
+        - verify-release
+    - name: update-release-channel
+      taskRef:
+        name: update-release-channel
+      params:
+        - name: release-name
+          value: $(tasks.pick-release.results.release-name)
+        - name: mirrored-release-pullspec
+          value: $(tasks.mirror.results.mirrored-pullspec)
+        - name: release-imagestream
+          value: $(params.release-imagestream)
+        - name: ci-cluster-secret-name
+          value: prow-okd-secret
+        - name: ci-cluster-secret-key
+          value: ci-prow-token
+      runAfter:
+        - mirror
+    - name: create-github-release
+      taskRef:
+        name: create-github-release
+      params:
+        - name: release-name
+          value: $(tasks.pick-release.results.release-name)
+        - name: mirrored-release-pullspec
+          value: $(tasks.mirror.results.mirrored-pullspec)
+        - name: github-token-secret-name
+          value: gh-token
+        - name: github-token-secret-key
+          value: gh-okd-token
+        - name: gpg-secret-name
+          value: okd-private-key
+        - name: gpg-secret-name
+          value: okd-private-key
+        - name: gpg-secret-key-name
+          value: private.key
+        - name: gpg-key-id
+          value: maintainers@okd.io
+      runAfter:
+        - verify-release

--- a/pipelines/okd-release-pipeline.yaml
+++ b/pipelines/okd-release-pipeline.yaml
@@ -16,6 +16,18 @@ spec:
     - description: The app.ci imagestream to use for tagging (e.g., release or release-scos)
       name: release-imagestream
       type: string
+    - description: The content mirror destination
+      name: content-mirror-pushspec
+      type: string
+      default: "quay.io/zzlotnik/scos-content"
+    - description: The release mirror destination
+      name: release-mirror-pushspec
+      type: string
+      default: "quay.io/zzlotnik/scos-release"
+    - description: The GitHub org/repo to release to
+      name: github-org-repo
+      type: string
+      default: "cheesesashimi/okd-release-test"
   tasks:
     - name: build-pipeline-worker-image
       taskRef:
@@ -42,6 +54,27 @@ spec:
           value: $(tasks.pick-release.results.release-digest)
       runAfter:
         - pick-release
+    - name: prepare-binaries
+      taskRef:
+        name: prepare-release-binaries
+      params:
+        - name: release-name
+          value: $(tasks.pick-release.results.release-name)
+        - name: release-pullspec
+          value: $(tasks.pick-release.results.release-pullspec)
+        - name: gpg-secret-name
+          value: okd-private-key
+        - name: gpg-secret-name
+          value: okd-private-key
+        - name: gpg-secret-key-name
+          value: private.key
+        - name: gpg-key-id
+          value: maintainers@okd.io
+      runAfter:
+        - verify-release
+      workspaces:
+        - name: release-binaries
+          workspace: release-binaries
     - name: mirror
       taskRef:
         name: mirror-release
@@ -52,18 +85,44 @@ spec:
           value: $(tasks.pick-release.results.release-pullspec)
         - name: image-push-secret-name
           value: okd-okd-robot-pull-secret
-        - name: content-mirror-pushspec
-          value: quay.io/okd/scos-content
         - name: release-mirror-pushspec
-          value: "quay.io/okd/scos-release"
-        - name: gpg-secret-name
-          value: okd-private-key
-        - name: gpg-secret-key-name
-          value: private.key
-        - name: gpg-key-id
-          value: maintainers@okd.io
+          value: $(params.release-mirror-pushspec)
+        - name: content-mirror-pushspec
+          value: $(params.content-mirror-pushspec)
       runAfter:
         - verify-release
+    - name: prepare-release-notes
+      taskRef:
+        name: prepare-release-notes
+      params:
+        - name: release-name
+          value: $(tasks.pick-release.results.release-name)
+        - name: mirrored-release-pullspec
+          value: $(tasks.mirror.results.mirrored-pullspec)
+      runAfter:
+        - mirror
+      workspaces:
+        - name: release-binaries
+          workspace: release-binaries
+    - name: create-github-release
+      taskRef:
+        name: create-github-release
+      params:
+        - name: release-name
+          value: $(tasks.pick-release.results.release-name)
+        - name: github-token-secret-name
+          value: gh-token
+        - name: github-token-secret-key
+          value: gh-okd-token
+        - name: github-org-repo
+          value: $(params.github-org-repo)
+      runAfter:
+        - prepare-binaries
+        - prepare-release-notes
+        - mirror
+      workspaces:
+        - name: release-binaries
+          workspace: release-binaries
     - name: update-release-channel
       taskRef:
         name: update-release-channel
@@ -79,26 +138,6 @@ spec:
         - name: ci-cluster-secret-key
           value: ci-prow-token
       runAfter:
-        - mirror
-    - name: create-github-release
-      taskRef:
-        name: create-github-release
-      params:
-        - name: release-name
-          value: $(tasks.pick-release.results.release-name)
-        - name: mirrored-release-pullspec
-          value: $(tasks.mirror.results.mirrored-pullspec)
-        - name: github-token-secret-name
-          value: gh-token
-        - name: github-token-secret-key
-          value: gh-okd-token
-        - name: gpg-secret-name
-          value: okd-private-key
-        - name: gpg-secret-name
-          value: okd-private-key
-        - name: gpg-secret-key-name
-          value: private.key
-        - name: gpg-key-id
-          value: maintainers@okd.io
-      runAfter:
-        - verify-release
+        - create-github-release
+  workspaces:
+    - name: release-binaries

--- a/tasks/create-github-release.yaml
+++ b/tasks/create-github-release.yaml
@@ -9,9 +9,6 @@ spec:
     - description: The release name to target
       name: release-name
       type: string
-    - description: The mirrored release pullspec to target
-      name: mirrored-release-pullspec
-      type: string
     - description: The Kubernetes secret containing a GitHub token
       name: github-token-secret-name
       type: string
@@ -20,18 +17,6 @@ spec:
       name: github-token-secret-key
       type: string
       default: zzlotnik-gh-okd-token
-    - description: The GPG key ID to sign the release
-      name: gpg-key-id
-      type: string
-      default: okd@not.real.go.away
-    - description: The Kube secret name containing the GPG signing key
-      name: gpg-secret-name
-      type: string
-      default: release-signing-gpg-key
-    - description: The Kube secret key containing the GPG signing key
-      name: gpg-secret-key-name
-      type: string
-      default: fake-okd-signing-key.key
     - description: The GitHub org/repo to release to
       name: github-org-repo
       type: string
@@ -42,8 +27,6 @@ spec:
       env:
         - name: RELEASE_NAME
           value: $(params.release-name)
-        - name: MIRRORED_RELEASE_PULLSPEC
-          value: $(params.mirrored-release-pullspec)
         - name: GH_TOKEN
           valueFrom:
             secretKeyRef:
@@ -53,51 +36,15 @@ spec:
         #!/usr/bin/env bash
         set -euxo pipefail
 
-        # Retrieve the release info, including the pullspecs
-        release_pullspecs="$(oc adm release info --pullspecs "$MIRRORED_RELEASE_PULLSPEC")"
-
-        # Load the release notes template from the ConfigMap
-        release_notes_template="$(cat /var/release-notes-template/release-notes-template.txt)"
-
-        # Substitute the template placeholder for the release info
-        release_notes="${release_notes_template/release_pullspec/$release_pullspecs}"
-
-        client_utils_dir="okd-scos-$RELEASE_NAME"
-
-        # Download and extract the CLI tools from the release
-        oc adm release extract \
-            --command-os='*' \
-            --tools \
-            --to="$client_utils_dir" \
-            "$MIRRORED_RELEASE_PULLSPEC"
-
-        export GPG_TTY=$(tty)
-        # Import our GPG key
-        # Note: I couldn't get this to work by doing gpg --batch --imoprt for some reason.
-        cat "/var/gpg-signing-key/$(params.gpg-secret-key-name)" | gpg --batch --import
-
-        # Sign our release
-        gpg --default-key "$(params.gpg-key-id)" --armor --detach-sign "$client_utils_dir/sha256sum.txt"
-        # Verify that we've signed the release
-        gpg --verify "$client_utils_dir/sha256sum.txt.asc" "$client_utils_dir/sha256sum.txt"
-
-        cd "$client_utils_dir"
+        cd "$(workspaces.release-binaries.path)/$RELEASE_NAME"
 
         # Create a new GitHub release and upload our assets
         # See: https://cli.github.com/ for details on the official GitHub CLI tool
         gh release create "$RELEASE_NAME" \
           --repo "$(params.github-org-repo)" \
-          --notes "$release_notes" \
+          --notes-file release-notes.txt \
           ./*.tar.gz ./*.txt ./*.txt.asc
-      volumeMounts:
-        - name: release-notes-template
-          mountPath: /var/release-notes-template
-        - name: gpg-signing-key
-          mountPath: /var/gpg-signing-key
-  volumes:
-    - name: release-notes-template
-      configMap:
-        name: release-notes-template
-    - name: gpg-signing-key
-      secret:
-        secretName: $(params.gpg-secret-name)
+  workspaces:
+    - name: release-binaries
+      description: The location we store the signed release binaries in
+      mountPath: /var/release-binaries

--- a/tasks/create-github-release.yaml
+++ b/tasks/create-github-release.yaml
@@ -1,0 +1,103 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: create-github-release
+  namespace: okd-team
+spec:
+  params:
+    - description: The release name to target
+      name: release-name
+      type: string
+    - description: The mirrored release pullspec to target
+      name: mirrored-release-pullspec
+      type: string
+    - description: The Kubernetes secret containing a GitHub token
+      name: github-token-secret-name
+      type: string
+      default: gh-token
+    - description: The secret key name for the GitHub token
+      name: github-token-secret-key
+      type: string
+      default: zzlotnik-gh-okd-token
+    - description: The GPG key ID to sign the release
+      name: gpg-key-id
+      type: string
+      default: okd@not.real.go.away
+    - description: The Kube secret name containing the GPG signing key
+      name: gpg-secret-name
+      type: string
+      default: release-signing-gpg-key
+    - description: The Kube secret key containing the GPG signing key
+      name: gpg-secret-key-name
+      type: string
+      default: fake-okd-signing-key.key
+    - description: The GitHub org/repo to release to
+      name: github-org-repo
+      type: string
+      default: cheesesashimi/okd-release-test
+  steps:
+    - image: "image-registry.openshift-image-registry.svc:5000/okd-team/tekton-worker:latest"
+      name: "create-github-release"
+      env:
+        - name: RELEASE_NAME
+          value: $(params.release-name)
+        - name: MIRRORED_RELEASE_PULLSPEC
+          value: $(params.mirrored-release-pullspec)
+        - name: GH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.github-token-secret-name)
+              key: $(params.github-token-secret-key)
+      script: |
+        #!/usr/bin/env bash
+        set -euxo pipefail
+
+        # Retrieve the release info, including the pullspecs
+        release_pullspecs="$(oc adm release info --pullspecs "$MIRRORED_RELEASE_PULLSPEC")"
+
+        # Load the release notes template from the ConfigMap
+        release_notes_template="$(cat /var/release-notes-template/release-notes-template.txt)"
+
+        # Substitute the template placeholder for the release info
+        release_notes="${release_notes_template/release_pullspec/$release_pullspecs}"
+
+        client_utils_dir="okd-scos-$RELEASE_NAME"
+
+        # Download and extract the CLI tools from the release
+        oc adm release extract \
+            --command-os='*' \
+            --tools \
+            --to="$client_utils_dir" \
+            "$MIRRORED_RELEASE_PULLSPEC"
+
+        export GPG_TTY=$(tty)
+        # Import our GPG key
+        # Note: I couldn't get this to work by doing gpg --batch --imoprt for some reason.
+        cat "/var/gpg-signing-key/$(params.gpg-secret-key-name)" | gpg --batch --import
+
+        # Sign our release
+        gpg --default-key "$(params.gpg-key-id)" --armor --detach-sign "$client_utils_dir/sha256sum.txt"
+        # Verify that we've signed the release
+        gpg --verify "$client_utils_dir/sha256sum.txt.asc" "$client_utils_dir/sha256sum.txt"
+
+        cd "$client_utils_dir"
+
+        # Create a new GitHub release and upload our assets
+        # See: https://cli.github.com/ for details on the official GitHub CLI tool
+        gh release create "$RELEASE_NAME" \
+          --repo "$(params.github-org-repo)" \
+          --notes "$release_notes" \
+          ./*.tar.gz ./*.txt ./*.txt.asc
+      volumeMounts:
+        - name: release-notes-template
+          mountPath: /var/release-notes-template
+        - name: gpg-signing-key
+          mountPath: /var/gpg-signing-key
+  volumes:
+    - name: release-notes-template
+      configMap:
+        name: release-notes-template
+    - name: gpg-signing-key
+      secret:
+        secretName: $(params.gpg-secret-name)

--- a/tasks/mirror-release.yaml
+++ b/tasks/mirror-release.yaml
@@ -23,14 +23,11 @@ spec:
     - description: The content mirror destination
       name: content-mirror-pushspec
       type: string
-      default: "quay.io/zzlotnik/scos-content"
     - description: The release mirror destination
       name: release-mirror-pushspec
       type: string
-      default: "quay.io/zzlotnik/scos-release"
   results:
     - name: mirrored-pullspec
-      # type: string
   steps:
     - image: "image-registry.openshift-image-registry.svc:5000/okd-team/tekton-worker:latest"
       name: "mirror-release-to-quay"

--- a/tasks/mirror-release.yaml
+++ b/tasks/mirror-release.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mirror-release
+  namespace: okd-team
+spec:
+  params:
+    - description: The release name to target
+      name: release-name
+      type: string
+    - description: The release pullspec to target
+      name: release-pullspec
+      type: string
+    - description: The image push secret name to use
+      name: image-push-secret-name
+      type: string
+      default: zzlotnik-okdpipelinepush-pull-secret
+    - description: The URL for the GPG public key to use for verification
+      name: gpg-public-key-url
+      type: string
+      default: "https://raw.githubusercontent.com/openshift/cluster-update-keys/master/keys/verifier-public-key-openshift-ci-2"
+    - description: The content mirror destination
+      name: content-mirror-pushspec
+      type: string
+      default: "quay.io/zzlotnik/scos-content"
+    - description: The release mirror destination
+      name: release-mirror-pushspec
+      type: string
+      default: "quay.io/zzlotnik/scos-release"
+  results:
+    - name: mirrored-pullspec
+      # type: string
+  steps:
+    - image: "image-registry.openshift-image-registry.svc:5000/okd-team/tekton-worker:latest"
+      name: "mirror-release-to-quay"
+      script: |
+        #!/usr/bin/env bash
+        set -euxo pipefail
+
+        RELEASE="$(params.release-pullspec)"
+        RELEASE_NAME="$(params.release-name)"
+
+        CONTENT_MIRROR="$(params.content-mirror-pushspec):${RELEASE_NAME}"
+        RELEASE_MIRROR="$(params.release-mirror-pushspec):${RELEASE_NAME}"
+
+        # Import the public key for verification
+        curl -Lv "$(params.gpg-public-key-url)" | gpg --import
+
+        oc adm release new \
+          --registry-config="/secret/image-push-secret/.dockerconfigjson" \
+          --from-release "$RELEASE" \
+          --mirror "$(params.content-mirror-pushspec)" \
+          --to-image "$RELEASE_MIRROR" \
+          --name="$RELEASE_NAME"
+
+        printf "%s" "$RELEASE_MIRROR" > $(results.mirrored-pullspec.path)
+      volumeMounts:
+        - name: "image-push-secret"
+          mountPath: /secret/image-push-secret
+  volumes:
+    - name: "image-push-secret"
+      secret:
+        secretName: "$(params.image-push-secret-name)"

--- a/tasks/pick-release.yaml
+++ b/tasks/pick-release.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: pick-release
+  namespace: okd-team
+spec:
+  params:
+    - description: The release controller to target
+      name: release-controller
+      type: string
+      default: "https://origin-release.ci.openshift.org"
+    - description: The release stream (e.g., 4.13.0-0.okd) to target.
+      name: release-stream
+      type: string
+  results:
+    - name: release-name
+    - name: release-pullspec
+    - name: release-digest
+  steps:
+    - image: "image-registry.openshift-image-registry.svc:5000/okd-team/tekton-worker:latest"
+      name: "pick-release"
+      script: |
+        #!/usr/bin/env bash
+        set -xuo pipefail
+
+        # The latest endpoint returns the latest accepted release, so we don't have to do any special filtering.
+        # See: https://github.com/openshift/release-controller/blob/master/pkg/release-controller/release.go#L493-L522
+        RELEASE="$(curl "$(params.release-controller)/api/v1/releasestream/$(params.release-stream)/latest")"
+
+        RELEASE_NAME="$(echo "$RELEASE" | jq -r '.name')"
+        RELEASE_PULLSPEC="$(echo "$RELEASE" | jq -r '.pullSpec')"
+        DIGEST="$(oc adm release info --output=jsonpath='{.digest}' "$RELEASE_PULLSPEC")"
+
+        # Use printf instead of echo so we don't end up with newlines.
+        printf "%s" "$RELEASE_NAME" > $(results.release-name.path)
+        printf "%s" "$RELEASE_PULLSPEC" > $(results.release-pullspec.path)
+        printf "%s" "$DIGEST" > $(results.release-digest.path)

--- a/tasks/prepare-release-binaries.yaml
+++ b/tasks/prepare-release-binaries.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: prepare-release-binaries
+  namespace: okd-team
+spec:
+  params:
+    - description: The release name to target
+      name: release-name
+      type: string
+    - description: The release pullspec to target
+      name: release-pullspec
+      type: string
+    - description: The GPG key ID to sign the release
+      name: gpg-key-id
+      type: string
+      default: okd@not.real.go.away
+    - description: The Kube secret name containing the GPG signing key
+      name: gpg-secret-name
+      type: string
+      default: release-signing-gpg-key
+    - description: The Kube secret key containing the GPG signing key
+      name: gpg-secret-key-name
+      type: string
+      default: fake-okd-signing-key.key
+  steps:
+    - image: "image-registry.openshift-image-registry.svc:5000/okd-team/tekton-worker:latest"
+      name: "prepare-release-binaries"
+      env:
+        - name: RELEASE_NAME
+          value: $(params.release-name)
+        - name: RELEASE_PULLSPEC
+          value: $(params.release-pullspec)
+      script: |
+        #!/usr/bin/env bash
+        set -euxo pipefail
+
+        client_utils_dir="./okd-tools/$RELEASE_NAME"
+
+        mkdir -p "$client_utils_dir"
+
+        # Download and extract the CLI tools from the release
+        oc adm release extract \
+            --command-os='*' \
+            --tools \
+            --to="$client_utils_dir" \
+            "$RELEASE_PULLSPEC"
+
+        export GPG_TTY=$(tty)
+        # Import our GPG key
+        # Note: I couldn't get this to work by doing gpg --batch --imoprt for some reason.
+        cat "/var/gpg-signing-key/$(params.gpg-secret-key-name)" | gpg --batch --import
+
+        # Sign our release
+        gpg --default-key "$(params.gpg-key-id)" --armor --detach-sign "$client_utils_dir/sha256sum.txt"
+
+        # Verify that we've signed the release
+        gpg --verify "$client_utils_dir/sha256sum.txt.asc" "$client_utils_dir/sha256sum.txt"
+
+        # Need to copy the files to our PVC once we've signed them since trying
+        # to do them directly to our workspace volume causes gpg to require a
+        # TTY for reasons I don't understand.
+        mkdir -p "$(workspaces.release-binaries.path)/$RELEASE_NAME"
+        cp -r -v "$client_utils_dir/." "$(workspaces.release-binaries.path)/$RELEASE_NAME"
+        ls -la "$(workspaces.release-binaries.path)/$RELEASE_NAME"
+        du -h -c "$(workspaces.release-binaries.path)/$RELEASE_NAME"
+      volumeMounts:
+        - name: gpg-signing-key
+          mountPath: /var/gpg-signing-key
+  workspaces:
+  - name: release-binaries
+    description: The location we store the release binaries before uploading them
+    mountPath: /var/release-binaries
+  volumes:
+    - name: gpg-signing-key
+      secret:
+        secretName: $(params.gpg-secret-name)

--- a/tasks/prepare-release-notes.yaml
+++ b/tasks/prepare-release-notes.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: prepare-release-notes
+  namespace: okd-team
+spec:
+  params:
+    - description: The release name to target
+      name: release-name
+      type: string
+    - description: The mirrored release pullspec to target
+      name: mirrored-release-pullspec
+      type: string
+  steps:
+    - image: "image-registry.openshift-image-registry.svc:5000/okd-team/tekton-worker:latest"
+      name: "prepare-release-notes"
+      env:
+        - name: RELEASE_NAME
+          value: $(params.release-name)
+        - name: MIRRORED_RELEASE_PULLSPEC
+          value: $(params.mirrored-release-pullspec)
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        # Retrieve the release info, including the pullspecs
+        release_pullspecs="$(oc adm release info --pullspecs "$MIRRORED_RELEASE_PULLSPEC")"
+        template_file_path="/var/release-notes-template/"
+
+        if [[ "$RELEASE_NAME" == *"scos"* ]]; then
+          echo "Using the OKD on SCOS release notes template"
+          template_file_path="$template_file_path/scos-release-notes-template.txt"
+        else
+          echo "Using the OKD on FCOS release notes template"
+          template_file_path="$template_file_path/fcos-release-notes-template.txt"
+        fi
+
+        # Load the release notes template from the ConfigMap
+        release_notes_template="$(cat "$template_file_path")"
+
+        # Substitute the template placeholder for the release info
+        release_notes="${release_notes_template/release_pullspec/$release_pullspecs}"
+
+        # Write to file in workspace
+        mkdir -p "$(workspaces.release-binaries.path)/$RELEASE_NAME"
+        echo "$release_notes" > "$(workspaces.release-binaries.path)/$RELEASE_NAME/release-notes.txt"
+      volumeMounts:
+        - name: release-notes-template
+          mountPath: /var/release-notes-template
+  volumes:
+    - name: release-notes-template
+      configMap:
+        name: release-notes-template
+  workspaces:
+    - name: release-binaries
+      mountPath: /var/release-binaries

--- a/tasks/release-notes-template.yaml
+++ b/tasks/release-notes-template.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 data:
-  release-notes-template.txt: |
+  scos-release-notes-template.txt: |
     Client tools for OKD/SCOS
     -------------------------
 
@@ -15,6 +15,21 @@ data:
     ```
     release_pullspecs
     ```
+  fcos-release-notes-template.txt: |
+    Client tools for OKD
+    --------------------
+
+    These archives contain the client tooling for [OKD on Fedora CoreOS](https://docs.okd.io).
+
+    To verify the contents of this directory, use the 'gpg' and 'shasum' tools to
+    ensure the archives you have downloaded match those published from this location.
+
+    The openshift-install binary has been preconfigured to install the following release:
+
+    ```
+    release_pullspecs
+    ```
+
 kind: ConfigMap
 metadata:
   name: release-notes-template

--- a/tasks/release-notes-template.yaml
+++ b/tasks/release-notes-template.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+data:
+  release-notes-template.txt: |
+    Client tools for OKD/SCOS
+    -------------------------
+
+    These archives contain the client tooling for [OKD on CentOS Stream CoreOS](https://docs.okd.io).
+
+    To verify the contents of this directory, use the 'gpg' and 'shasum' tools to
+    ensure the archives you have downloaded match those published from this location.
+
+    The openshift-install binary has been preconfigured to install the following release:
+
+    ```
+    release_pullspecs
+    ```
+kind: ConfigMap
+metadata:
+  name: release-notes-template
+  namespace: okd-team

--- a/tasks/tekton-worker-image.yaml
+++ b/tasks/tekton-worker-image.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: tekton-worker
+  namespace: okd-team
+spec:
+  lookupPolicy:
+    local: false
+
+---
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: tekton-worker-image-build
+  namespace: okd-team
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: tekton-worker:latest
+  source:
+    dockerfile: |
+      FROM image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+      # The GitHub CLI team won't publish official container images for some reason, so we need to build our own
+      RUN curl -Lo gh-cli.rpm "https://github.com/cli/cli/releases/download/v2.20.2/gh_2.20.2_linux_amd64.rpm" && \
+        dnf install -y jq pinentry ./gh-cli.rpm && \
+        rm ./gh-cli.rpm
+    type: Dockerfile
+  strategy:
+    dockerStrategy: {}
+    type: Docker

--- a/tasks/update-release-channel.yaml
+++ b/tasks/update-release-channel.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: update-release-channel
+  namespace: okd-team
+spec:
+  params:
+    - description: The release name to target
+      name: release-name
+      type: string
+    - description: The mirrored release pullspec to target
+      name: mirrored-release-pullspec
+      type: string
+    - description: The oc project to target
+      name: oc-project
+      type: string
+      default: origin
+    - description: The CI cluster
+      name: ci-cluster
+      type: string
+      default: "https://api.ci.l2s4.p1.openshiftapps.com:6443"
+    - description: Secret name for CI cluster authentication
+      name: ci-cluster-secret-name
+      type: string
+    - description: Secret key name for CI cluster authentication
+      name: ci-cluster-secret-key
+      type: string
+    - description: The release ImageStream in the CI cluster to target
+      name: release-imagestream
+      type: string
+      default: release-scos
+  steps:
+    - image: "image-registry.openshift-image-registry.svc:5000/okd-team/tekton-worker:latest"
+      name: "update-release-channel"
+      env:
+        - name: CI_CLUSTER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.ci-cluster-secret-name)
+              key: $(params.ci-cluster-secret-key)
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        oc login --token="$CI_CLUSTER_TOKEN" --server="$(params.ci-cluster)"
+        oc project "$(params.oc-project)"
+        oc tag "$(params.mirrored-release-pullspec)" \
+          "$(params.release-imagestream):$(params.release-name)"

--- a/tasks/verify-release.yaml
+++ b/tasks/verify-release.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: gpg-verify-release
+  namespace: okd-team
+spec:
+  params:
+    - description: The release digest to verify
+      name: release-digest
+      type: string
+    - description: The URL for the GPG public key to use for verification
+      name: gpg-public-key-url
+      type: string
+      default: "https://raw.githubusercontent.com/openshift/cluster-update-keys/master/keys/verifier-public-key-openshift-ci-2"
+  steps:
+    - image: "image-registry.openshift-image-registry.svc:5000/okd-team/tekton-worker:latest"
+      name: "gpg-verify"
+      script: |
+        #!/usr/bin/env bash
+        set -euxo pipefail
+
+        # Import the public key for verification
+        curl -Lv "$(params.gpg-public-key-url)" | gpg --import
+
+        # Trim off the sha256: prefix so it can be found in the GCS bucket.
+        DIGEST="$(params.release-digest)"
+        DIGEST="${DIGEST/sha256\:/}"
+        curl -Lvs "https://storage.googleapis.com/openshift-ci-release/releases/signatures/openshift/release/sha256=${DIGEST}/signature-1" | gpg -d


### PR DESCRIPTION
This is my attempt at automating the OKD release instructions. In its current state, it works, but still has a few remaining TODOs that I'm aware of:

~- Need to sign releases before uploading to GitHub.~
~- Need to figure out credentials for the `oc tag` step in apps.ci.~

- Need to wire up Kustomize for everything. I'm not sure what the best way is to do that though, so will need to do some research.
- Add Operate First-specific configs and secrets.

At this point, we just need to iron out some of the details with Kustomize, namespacing, and secrets.
