### PR TITLE
Configure 60s timeout on `oc adm release new` for task mirror-release

### DIFF
--- a/pipelines/okd-release-pipeline.yaml
+++ b/pipelines/okd-release-pipeline.yaml
@@ -64,8 +64,6 @@ spec:
           value: $(tasks.pick-release.results.release-pullspec)
         - name: gpg-secret-name
           value: okd-private-key
-        - name: gpg-secret-name
-          value: okd-private-key
         - name: gpg-secret-key-name
           value: private.key
         - name: gpg-key-id

--- a/tasks/mirror-release.yaml
+++ b/tasks/mirror-release.yaml
@@ -45,6 +45,7 @@ spec:
         curl -Lv "$(params.gpg-public-key-url)" | gpg --import
 
         oc adm release new \
+          --request-timeout=60s \
           --registry-config="/secret/image-push-secret/.dockerconfigjson" \
           --from-release "$RELEASE" \
           --mirror "$(params.content-mirror-pushspec)" \


### PR DESCRIPTION
Remove duplicate parameter on okd-release-pipeline