### PR TITLE
Introducing argo workflows: deployment + multi-arch-build and okd-build ClusterWorkflowTemplate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,4 @@ tags
 # Persistent undo
 [._]*.un~
 
+.env

--- a/REAMDE.md
+++ b/REAMDE.md
@@ -1,0 +1,15 @@
+# OKD Payload pipeline
+
+## Introduction
+
+TODO
+
+#### Tekton pipelines
+
+TODO 
+
+#### Argo workflows & Multi-arch OKD
+
+Refers to [argo-workflows/README.md](argo-workflows/README.md) for more details.
+
+

--- a/argo-workflows/README.md
+++ b/argo-workflows/README.md
@@ -1,0 +1,114 @@
+### Deploy argo-workflow
+
+[temporary workaround]
+
+Create an overlay or directly replace the ${ARGO_FINAL_URL} string with the url the argo-workflows route will be exposed on.
+It is argo-server-${NAMESPACE}.apps.${CLUSTER_NAME}.${BASE_DOMAIN} by default.
+
+[/temporary workaround]
+
+```shell
+oc apply -k argo-workflows/operator-deployment
+```
+
+### Deploy the okd workflows and build configs
+
+```shell
+oc apply -k variants/fcos-multiarch
+```
+
+If taints on the secondary architecture nodes are set, annotate the namespace to allow scheduling builds on those nodes
+
+```shell
+oc annotate namespace argo-workflows-build-example \
+  'scheduler.alpha.kubernetes.io/defaultTolerations'='[{"operator": "Exists", "effect": "NoSchedule", "key": "arm64"}]'
+```
+
+To run the workflow from the WorkflowTemplate, create a Workflow object like:
+
+```shell
+oc create -f - <<EOF
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+    generateName: builder-build-workflow-
+spec:
+  arguments:
+    parameters:
+    - name: architectures
+      value: amd64,arm64
+    - name: build-config-name
+      value: builder
+  workflowTemplateRef:
+    name: build-multiarch-image
+    clusterScope: true
+EOF
+```
+
+# Build okd 
+
+```shell
+oc create -f - <<EOF
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+    generateName: okd-build
+spec:
+  arguments:
+    parameters:
+    - name: architectures
+      value: amd64,arm64
+    - name: cleanup
+      value: "true" # deletes any previously built images
+    - name: os-image
+      value: quay.io/okd/centos-stream-coreos-9:4.12-x86_64
+    - name: os-name
+      value: centos-stream-coreos-9
+  workflowTemplateRef:
+    name: build-okd
+    clusterScope: true
+EOF
+
+```
+
+This workflow will import the image at os-image and build the okd release by consuming it.
+
+If, instead, as in the FCOS case, you should build with layering, use the following workflow:
+
+```shell
+ oc create -f - <<EOF
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+    generateName: okd-
+spec:
+  arguments:
+    parameters:
+    - name: architectures
+      value: amd64,arm64
+    - name: cleanup
+      value: "false"
+    - name: os-buildconfig
+      value: fedora-coreos
+    - name: os-name
+      value: fedora-coreos
+    - name: release-image-location 
+      value: quay.io/<org>/okd-release-argo:4.13.0-0.okd-2204161150z
+    - name: release-mirror-location
+      value: quay.io/<org>/okd-release-argo
+    - name: registry-credentials-secret-ref
+      value: registry-robot-token
+  workflowTemplateRef:
+    name: build-okd
+    clusterScope: true
+EOF
+
+```
+
+It takes a os-buildconfig value and lacks the os-image one, so that, at the end of the process, it will build the
+os content.
+
+## Package the OKD release (TODO)
+
+## Publish on quay and handle in the origin release-controller? (TODO)
+

--- a/argo-workflows/okd-workflows/15-rbac.yaml
+++ b/argo-workflows/okd-workflows/15-rbac.yaml
@@ -1,0 +1,104 @@
+kind: List
+apiVersion: v1
+items:
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: build-manager
+      namespace: argo-workflows-build-example
+      annotations:
+        description: |
+          This role will allow the bound service account to manage builds and get buildconfigs.
+          It is needed by the service account adapting the BuildConfigs into Builds to create and control.
+    rules:
+      - apiGroups:
+          - ""
+          - build.openshift.io
+        resources:
+          - builds
+        verbs:
+          - get
+          - create
+          - update
+          - delete
+      - apiGroups:
+          - ""
+          - build.openshift.io
+        resources:
+          - buildconfigs
+        verbs:
+          - get
+      - apiGroups:
+          - "image.openshift.io"
+        resources:
+          - imagestreamtags
+          - imagestreams
+        verbs:
+          # to delete the single-arch manifest imagestreamtags
+          # and handle the cleanup of the release imagestream
+          - delete
+          - create
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: argo-workflows-controller
+      namespace: argo-workflows-build-example
+      annotations:
+        description: |
+          This role is needed to allow the output parameters handling and to set the finalizers of the workflows objects
+          when the setOwnerReference field is used by their steps.
+    rules:
+      - apiGroups:
+          - argoproj.io
+        resources:
+          - workflowtaskresults
+          - workflows/finalizers
+        verbs:
+          - create
+          - get
+          - patch
+          - delete
+          - update
+      - apiGroups:
+          - argoproj.io
+        resources:
+          - workflows
+        verbs:
+          - create
+          - get
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: workflows-build-manager
+      namespace: argo-workflows-build-example
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: build-manager
+    subjects:
+      - kind: ServiceAccount
+        name: workflows
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: workflows-argo-workflows-exec
+      namespace: argo-workflows-build-example
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: argo-workflows-controller
+    subjects:
+      - kind: ServiceAccount
+        name: workflows
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: argo-image-builder
+      namespace: argo-workflows-build-example
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:image-builder
+    subjects:
+      - kind: ServiceAccount
+        name: workflows

--- a/argo-workflows/okd-workflows/30-build-workflow-template.yaml
+++ b/argo-workflows/okd-workflows/30-build-workflow-template.yaml
@@ -1,0 +1,185 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ClusterWorkflowTemplate
+metadata:
+  name: build-multiarch-image
+spec:
+  ttlStrategy:
+    secondsAfterFailure: 86400
+    secondsAfterSuccess: 8400
+  entrypoint: entrypoint
+  arguments:
+    parameters:
+      - name: build-config-name
+      - name: architectures
+  templates:
+    - name: entrypoint
+      steps:
+        - - name: generate-params
+            template: csv-to-json-array
+            arguments:
+              parameters:
+                - name: list
+                  value: "{{workflow.parameters.architectures}}"
+        - - name: build-single-arch-manifests
+            template: build-single-arch-manifest
+            arguments:
+              parameters:
+                - name: build-config-name
+                  value: "{{workflow.parameters.build-config-name}}"
+                - name: architecture
+                  value: "{{item}}"
+            withParam: "{{steps.generate-params.outputs.result}}"
+        - - name: compose-manifest-list
+            template: compose-manifest-list
+            arguments:
+              parameters:
+                - name: final-image
+                  value: "{{steps.build-single-arch-manifests.outputs.parameters.final-image}}"
+                - name: architectures
+                  value: "{{workflow.parameters.architectures}}"
+    - name: build-single-arch-manifest
+      inputs:
+        parameters:
+          - name: architecture
+            description: The architecture to build the manifest for
+          - name: build-config-name
+      outputs:
+        parameters:
+          - name: final-image
+            valueFrom:
+              parameter: "{{steps.build-generate.outputs.parameters.final-image}}"
+      steps:
+        - - name: build-generate
+            template: build-generate
+            arguments:
+              parameters:
+                - name: architecture
+                  value: "{{inputs.parameters.architecture}}"
+                - name: build-config-name
+                  value: "{{inputs.parameters.build-config-name}}"
+        - - name: build-run-and-wait
+            template: build-run-and-wait
+            arguments:
+              parameters:
+                - name: build
+                  value: "{{steps.build-generate.outputs.parameters.build}}"
+    - name: build-generate
+      inputs:
+        parameters:
+          - name: architecture
+          - name: build-config-name
+      outputs:
+        parameters:
+          - name: build
+            valueFrom:
+              path: /tmp/build.yaml
+          - name: final-image
+            valueFrom:
+              path: /tmp/final-image
+      script:
+        # TODO: Can I use a resource template + action get + jqFilter in the output?
+        # TODO: use an image including both kubectl and yq?
+        image: image-registry.openshift-image-registry.svc:5000/openshift/cli
+        command:
+          - bash
+        source: |
+          #!/bin/bash
+          set -xeo pipefail
+          arch=$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/;')
+          wget -O /tmp/yq "https://github.com/mikefarah/yq/releases/download/v4.32.2/yq_linux_${arch}"
+          chmod +x /tmp/yq
+          /tmp/yq eval-all '
+            select(fileIndex == 0) * select(fileIndex == 1) |
+            del(.spec.failedBuildsHistoryLimit) |
+            del(.status) |
+            del(.spec.runPolicy) |
+            del(.spec.successfulBuildsHistoryLimit) |
+            del(.metadata.creationTimestamp) |
+            del(.metadata.uid) |
+            del(.metadata.resourceVersion) |
+            del(.metadata.annotations) |
+            .metadata.generateName = .metadata.name + "-{{inputs.parameters.architecture}}-" |
+            .spec.output.to.name = .spec.output.to.name + "-{{inputs.parameters.architecture}}" |
+            del(.metadata.name)
+          ' \
+            <(kubectl get "bc/{{inputs.parameters.build-config-name}}" -o yaml) - <<EOF | tee /tmp/build.yaml
+            kind: Build
+            spec:
+              nodeSelector: 
+                kubernetes.io/arch: {{inputs.parameters.architecture}}
+          EOF
+          
+          image=$(/tmp/yq -r '.spec.output.to.name' /tmp/build.yaml)
+          namespace=$(/tmp/yq -r '.spec.output.to.namespace' /tmp/build.yaml)
+          if [ "$namespace" == "null" ]; then
+            # Use the namespace associated with the service account running this container
+            namespace=$(</var/run/secrets/kubernetes.io/serviceaccount/namespace)
+          fi
+          echo "image-registry.openshift-image-registry.svc:5000/$namespace/${image%-*}" > /tmp/final-image
+    - name: build-run-and-wait
+      inputs:
+        parameters:
+          - name: build
+      resource:
+        action: create
+        setOwnerReference: true
+        successCondition: status.phase in (Complete)
+        failureCondition: status.phase in (Failed)
+        manifest: |
+          {{inputs.parameters.build}}
+    - name: compose-manifest-list
+      inputs:
+        parameters:
+          - name: final-image
+          - name: architectures
+      script:
+        image: image-registry.openshift-image-registry.svc:5000/openshift/cli
+        command:
+          - bash
+        source: |
+          #!/bin/bash
+          set -euo pipefail
+          # TODO another image? The current official manifest-tool image extends from scratch 
+          # and we cannot use files redirection in the args list if using it
+          wget -O /tmp/binaries-manifest-tool.tar.gz https://github.com/estesp/manifest-tool/releases/download/v2.0.8/binaries-manifest-tool-2.0.8.tar.gz
+          tar -C /tmp --transform 's/manifest-tool-linux-.*/mtl/' \
+            -xvf /tmp/binaries-manifest-tool.tar.gz manifest-tool-linux-$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/')
+          image='{{inputs.parameters.final-image}}'
+          image="${image%\",*}"
+          image="${image#\[\"}"
+          mapfile -t architectures < <(echo "{{inputs.parameters.architectures}}" | tr ',' '\n')
+          echo "[INFO] Creating manifest list ${image} with manifests for architectures ${architectures[*]}"         
+          MANIFEST_LIST="
+          image: ${image}
+          manifests:"
+          for arch in "${architectures[@]}"; do
+            MANIFEST_LIST="${MANIFEST_LIST}
+            - image: ${image}-${arch}
+              platform:
+                architecture: ${arch}
+                os: linux"
+          done
+          echo "${MANIFEST_LIST}"          
+          /tmp/mtl --insecure --username k8s --password "$(</var/run/secrets/kubernetes.io/serviceaccount/token)" \
+            push from-spec <(echo "${MANIFEST_LIST}")
+          
+          echo "[INFO] Manifest list pushed to ${image}. Deleting individual manifests..."
+          set -x
+          image="${image#image-registry.openshift-image-registry.svc:5000/}"
+          namespace="${image%%/*}"
+          image="${image#*/}"
+          for arch in "${architectures[@]}"; do
+            oc delete -n ${namespace} istag "${image}-${arch}"
+          done
+          echo "[INFO] Done."
+    - name: csv-to-json-array
+      inputs:
+        parameters:
+          - name: list
+      script:
+        image: image-registry.openshift-image-registry.svc:5000/openshift/python:3.9-ubi9
+        command: [python]
+        source: |
+          import json
+          l = "{{inputs.parameters.list}}"
+          print(json.dumps(l.split(",")))

--- a/argo-workflows/okd-workflows/40-build-from-scratch.yaml
+++ b/argo-workflows/okd-workflows/40-build-from-scratch.yaml
@@ -1,0 +1,568 @@
+kind: ClusterWorkflowTemplate
+apiVersion: argoproj.io/v1alpha1
+metadata:
+  name: build-okd
+spec:
+  entrypoint: entrypoint
+  arguments:
+    parameters:
+      - name: architectures
+      - name: cleanup
+      - default: ""
+        name: os-image
+        value: ""
+      - name: os-name
+      - default: ""
+        name: os-buildconfig
+        value: ""
+      - default: quay.io/<org>/okd-release-argo:4.13.0-0.okd-2021-12-11-200126
+        name: release-image-location
+      - default: quay.io/<org>/okd-release-argo
+        name: release-mirror-location
+      - default: registry-robot-token
+        name: registry-credentials-secret-ref
+  templates:
+    - name: entrypoint
+      steps:
+        - - name: cleanup
+            when: "{{workflow.parameters.cleanup}}==true"
+            template: cleanup
+        - - name: recreate-os-imagestreamtags
+            template: recreate-os-imagestreamtags
+            when: '''{{workflow.parameters.os-buildconfig}}''=='''''
+            arguments:
+              parameters:
+                - name: os-name
+                  value: "{{item}}"
+                - name: os-image
+                  value: "{{workflow.parameters.os-image}}"
+            withItems:
+              - "{{workflow.parameters.os-name}}"
+              - machine-os-content
+        - - name: initial
+            template: initial
+        - - name: batches
+            template: batches
+        - - name: build-os
+            template: build-os
+            when: '''{{workflow.parameters.os-buildconfig}}''!='''''
+        - - name: package-release
+            template: package-release
+            arguments:
+              parameters:
+                - name: release-image-location
+                  value: '{{workflows.paramters.release-image-location}}'
+                - name: release-mirror-location
+                  value: '{{workflows.paramters.release-mirror-location}}'
+    - name: build-os
+      steps:
+        - - arguments:
+              parameters:
+                - name: build-config-name
+                  value: '{{workflow.parameters.os-buildconfig}}'
+            name: build-os
+            template: build-multiarch-workflow
+        - - inline:
+              resource:
+                action: apply
+                manifest: |
+                  apiVersion: image.openshift.io/v1
+                  kind: ImageStreamTag
+                  metadata:
+                    name: release:machine-os-content
+                  tag:
+                    from:
+                      kind: ImageStreamTag
+                      name: "release:{{workflow.parameters.os-name}}"
+                    importPolicy:
+                      importMode: PreserveOriginal
+            name: set-machine-os-content
+    - name: build-multiarch-workflow
+      inputs:
+        parameters:
+          - name: build-config-name
+      retryStrategy:
+        backoff:
+          duration: 1m
+          factor: "2"
+          maxDuration: 60m
+        limit: "3"
+        retryPolicy: Always
+      steps:
+        - - name: generate-memoization-key
+            arguments:
+              parameters:
+                - name: build-config-name
+                  value: "{{inputs.parameters.build-config-name}}"
+            template: prepare-memoization-key
+        - - name: multiarch-build
+            template: multiarch-builds
+            arguments:
+              parameters:
+                - name: build-config-name
+                  value: "{{inputs.parameters.build-config-name}}"
+                - name: memoization-key
+                  value: "{{steps.generate-memoization-key.outputs.parameters.memoization-key}}"
+    - name: initial
+      failFast: true
+      parallelism: 1
+      steps:
+        - - name: prepare-build-images
+            template: build-multiarch-workflow
+            arguments:
+                parameters:
+                  - name: build-config-name
+                    value: "{{item}}"
+                  - name: architectures
+                    value: "{{workflow.parameters.architectures}}"
+            withItems:
+              - builder
+              - forked-dockerfiles
+              - base
+              - cli
+    - name: batches
+      failFast: true
+      parallelism: 8
+      steps:
+        - - name: batch-01
+            template: build-multiarch-workflow
+            arguments:
+              parameters:
+                - name: build-config-name
+                  value: "{{item}}"
+                - name: architectures
+                  value: "{{workflow.parameters.architectures}}"
+            withItems:
+            - agent-installer-node-agent
+            - agent-installer-orchestrator
+            - alibaba-cloud-controller-manager
+            - alibaba-cloud-csi-driver
+            - alibaba-disk-csi-driver-operator
+            - alibaba-machine-controllers
+            - apiserver-network-proxy
+            - aws-cloud-controller-manager
+            - aws-cluster-api-controllers
+            - aws-ebs-csi-driver-operator
+            - aws-ebs-csi-driver
+            - aws-machine-controllers
+            - aws-pod-identity-webhook
+            - azure-cloud-controller-manager
+            - azure-cloud-node-manager
+            - azure-cluster-api-controllers
+            - azure-disk-csi-driver-operator
+            - azure-disk-csi-driver
+            - azure-file-csi-driver-operator
+            - azure-file-csi-driver
+            - azure-machine-controllers
+            - baremetal-machine-controllers
+            - baremetal-operator
+            - baremetal-runtimecfg
+            - branding
+            - cloud-credential-operator
+            - cloud-network-config-controller
+            - cluster-authentication-operator
+            - cluster-autoscaler-operator
+            - cluster-autoscaler
+            - cluster-baremetal-operator
+            - cluster-bootstrap
+            - cluster-capi-controllers
+            - cluster-capi-operator
+            - cluster-cloud-controller-manager-operator
+            - cluster-config-operator
+            - cluster-control-plane-machine-set-operator
+            - cluster-csi-snapshot-controller-operator
+            - cluster-dns-operator
+            - cluster-etcd-operator
+            - cluster-image-registry-operator
+            - cluster-ingress-operator
+            - cluster-kube-apiserver-operator
+            - cluster-kube-cluster-api-operator
+            - cluster-kube-controller-manager-operator
+            - cluster-kube-scheduler-operator
+            - cluster-kube-storage-version-migrator-operator
+            - cluster-machine-approver
+            - cluster-monitoring-operator
+            - cluster-network-operator
+            - cluster-openshift-apiserver-operator
+            - cluster-openshift-controller-manager-operator
+            - cluster-policy-controller
+            - cluster-samples-operator
+            - cluster-storage-operator
+            - cluster-update-keys
+            - cluster-version-operator
+            - configmap-reloader
+            - console-operator
+            - container-networking-plugins
+            - contour-operator
+            - contour
+            - coredns
+            - csi-driver-manila-operator
+            - csi-driver-manila
+            - csi-driver-nfs
+            - csi-driver-shared-resource-operator
+            - csi-driver-shared-resource-webhook
+            - csi-driver-shared-resource
+            - csi-external-attacher
+            - csi-external-provisioner
+            - csi-external-resizer
+            - csi-external-snapshotter
+            - csi-livenessprobe
+            - csi-node-driver-registrar
+            - csi-snapshot-controller
+            - csi-snapshot-validation-webhook
+            - docker-builder
+            - docker-registry
+            - egress-router-cni
+            - etcd
+            - external-dns
+            - gcp-cloud-controller-manager
+            - gcp-cluster-api-controllers
+            - gcp-machine-controllers
+            - gcp-pd-csi-driver-operator
+            - gcp-pd-csi-driver
+            - haproxy-router-base
+            - hypershift
+            - ibm-cloud-controller-manager
+            - ibm-vpc-block-csi-driver-operator
+            - ibm-vpc-block-csi-driver
+            - ibm-vpc-node-label-updater
+            - ibmcloud-machine-controllers
+            - insights-operator
+            - ironic-agent
+            - ironic-machine-os-downloader
+            - ironic-static-ip-manager
+            - k8s-prometheus-adapter
+            - keepalived-ipfailover
+            - kube-proxy
+            - kube-rbac-proxy
+            - kube-state-metrics
+            - kube-storage-version-migrator
+            - local-storage-static-provisioner
+            - machine-api-operator
+            - machine-config-operator
+            - machine-image-customization-controller
+            - multus-admission-controller
+            - multus-cni
+            - multus-networkpolicy
+            - multus-route-override-cni
+            - multus-whereabouts-ipam-cni
+            - must-gather
+            - bond-cni
+            - network-metrics-daemon
+            - nutanix-machine-controllers
+            - oauth-apiserver
+            - oauth-proxy
+            - oauth-server
+            - oc-mirror
+            - cli-artifacts
+            - openshift-apiserver
+            - openshift-controller-manager
+            - openshift-state-metrics
+            - openstack-cinder-csi-driver-operator
+            - openstack-cinder-csi-driver
+            - openstack-cloud-controller-manager
+            - openstack-machine-api-provider
+            - openstack-machine-controllers
+            - operator-lifecycle-manager
+            - operator-marketplace
+            - ovirt-csi-driver-operator
+            - ovirt-csi-driver
+            - ovirt-installer
+            - ovirt-machine-controllers
+            - pod
+            - powervs-cloud-controller-manager
+            - powervs-machine-controllers
+            - prom-label-proxy
+            - prometheus-alertmanager
+            - prometheus-config-reloader
+            - prometheus-node-exporter
+            - prometheus-operator-admission-webhook
+            - prometheus-operator
+            - prometheus
+            - route-controller-manager
+            - service-ca-operator
+            - telemeter
+            - thanos
+            - vsphere-cloud-controller-manager
+            - vsphere-cluster-api-controllers
+            - vsphere-csi-driver-operator
+            - vsphere-csi-driver-syncer
+            - vsphere-csi-driver
+            - vsphere-problem-detector
+            - cluster-node-tuning-operator
+            - ironic
+            - ironic-hardware-inventory-recorder
+            - libvirt-machine-controllers
+            - operator-registry
+            - sdn
+            - console
+            - baremetal-installer
+            - installer-artifacts
+            - installer
+            - hyperkube
+        - - name: batch-02
+            template: build-multiarch-workflow
+            arguments:
+              parameters:
+                - name: build-config-name
+                  value: "{{item}}"
+                - name: architectures
+                  value: "{{workflow.parameters.architectures}}"
+            withItems:
+            - agent-installer-api-server
+            - agent-installer-csr-approver
+            - artifacts
+            - tools
+            - haproxy-router
+            - ovn-kubernetes-base
+            - machine-os-images
+            - deployer
+        - - name: batch-03
+            template: build-multiarch-workflow
+            arguments:
+              parameters:
+                - name: build-config-name
+                  value: "{{item}}"
+                - name: architectures
+                  value: "{{workflow.parameters.architectures}}"
+            withItems:
+            - tests
+            - network-tools
+            - ovn-kubernetes-microshift
+            - ovn-kubernetes
+    - name: cleanup
+      steps:
+        - - name: delete-release-imagestream
+            continueOn:
+              failed: true
+              error: true
+            inline:
+              resource:
+                action: delete
+                manifest: |
+                  apiVersion: image.openshift.io/v1
+                  kind: ImageStream
+                  metadata:
+                    name: "release"
+        - - name: delete-memoization-configmap
+            template: delete-memoization-configmap
+        - - name: create-release-imagestream
+            inline:
+              resource:
+                action: create
+                manifest: |
+                  apiVersion: image.openshift.io/v1
+                  kind: ImageStream
+                  metadata:
+                    name: release
+                  spec:
+                    lookupPolicy:
+                      local: true
+                    tags:
+                      - name: kuryr-cni
+                        from:
+                          kind: DockerImage
+                          name: registry.access.redhat.com/ubi9-minimal:9.0.0
+                        referencePolicy:
+                          type: Source
+                        importPolicy:
+                          importMode: PreserveOriginal
+                      - name: kuryr-controller
+                        from:
+                          kind: DockerImage
+                          name: registry.access.redhat.com/ubi9-minimal:9.0.0
+                        referencePolicy:
+                          type: Source
+                        importPolicy:
+                          importMode: PreserveOriginal
+                      - name: powervs-block-csi-driver-operator
+                        from:
+                          kind: DockerImage
+                          name: registry.access.redhat.com/ubi9-minimal:9.0.0
+                        referencePolicy:
+                          type: Source
+                        importPolicy:
+                          importMode: PreserveOriginal
+                      - name: powervs-block-csi-driver
+                        from:
+                          kind: DockerImage
+                          name: registry.access.redhat.com/ubi9-minimal:9.0.0
+                        referencePolicy:
+                          type: Source
+                        importPolicy:
+                          importMode: PreserveOriginal
+                      - name: ibmcloud-cluster-api-controllers
+                        from:
+                          kind: DockerImage
+                          name: registry.access.redhat.com/ubi9-minimal:9.0.0
+                        referencePolicy:
+                          type: Source
+                        importPolicy:
+                          importMode: PreserveOriginal
+    - name: recreate-os-imagestreamtags
+      inputs:
+        parameters:
+          - name: os-name
+          - name: os-image
+      steps:
+        - - name: deleting-imagestreamtags
+            continueOn:
+              error: true
+              failed: true
+            inline:
+              resource:
+                action: delete
+                manifest: |
+                  apiVersion: image.openshift.io/v1
+                  kind: ImageStreamTag
+                  metadata:
+                    name: release:{{inputs.parameters.os-name}}
+        - - name: create-imagestreamtags
+            inline:
+              resource:
+                action: create
+                manifest: |
+                  apiVersion: image.openshift.io/v1
+                  kind: ImageStreamTag
+                  metadata:
+                    name: release:{{inputs.parameters.os-name}}
+                  tag:
+                    from:
+                      kind: DockerImage
+                      name: "{{inputs.parameters.os-image}}"
+                    referencePolicy:
+                      type: Source
+                    importPolicy:
+                      importMode: PreserveOriginal
+    - name: multiarch-builds
+      inputs:
+        parameters:
+          - name: build-config-name
+          - name: memoization-key
+      memoize:
+        key: "{{inputs.parameters.memoization-key}}"
+        maxAge: "6h"
+        cache:
+          configMap:
+            name: build-okd
+      resource:
+        action: create
+        successCondition: status.phase == Succeeded
+        failureCondition: status.phase in (Failed, Error)
+        setOwnerReference: true
+        manifest: |
+          apiVersion: argoproj.io/v1alpha1
+          kind: Workflow
+          metadata:
+            generateName: {{inputs.parameters.build-config-name}}-wf-
+          spec:
+            arguments:
+              parameters:
+              - name: build-config-name
+                value: "{{inputs.parameters.build-config-name}}"
+              - name: architectures
+                value: "{{workflow.parameters.architectures}}"
+            workflowTemplateRef:
+              name: build-multiarch-image
+              clusterScope: true
+    - name: prepare-memoization-key
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      inputs:
+        parameters:
+          - name: build-config-name
+      outputs:
+        parameters:
+          - name: memoization-params
+            valueFrom:
+              path: /tmp/volume/memoization-params
+          - name: memoization-key
+            valueFrom:
+              path: /tmp/volume/memoization-key
+      containerSet:
+        containers:
+          - name: prepare-memoization-params
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli
+            command: [bash, -c]
+            args:
+              - |
+                set -ex
+                echo "Preparing memoization params"
+                git_uri=$(oc get bc {{inputs.parameters.build-config-name}} -o jsonpath='{.spec.source.git.uri}')
+                git_revision=$(oc get bc {{inputs.parameters.build-config-name}} -o jsonpath='{.spec.source.git.ref}')
+                echo "git_uri=\"$git_uri\"" >> /tmp/volume/memoization-params
+                echo "git_revision=\"$git_revision\"" >> /tmp/volume/memoization-params
+                echo "name=\"{{inputs.parameters.build-config-name}}\"" >> /tmp/volume/memoization-params
+            volumeMounts:
+              - name: tmp
+                mountPath: /tmp/volume
+          - name: main
+            # this is on docker hub
+            image: alpine/git
+            command: [sh, -c]
+            args:
+              - |
+                set -exo pipefail
+                echo "Getting git revision sha"
+                . /tmp/volume/memoization-params
+                if [ -z "${git_uri}" ] || [ -z "${git_revision}" ]; then
+                  # TODO: this is for builds not using a git repo as source. For example, builds depending on previously
+                  # built images should use another strategy to define the memoization key
+                  echo "${name}-$(cat /run/secrets/kubernetes.io/serviceaccount/namespace)-$(cat /proc/sys/kernel/random/uuid)" > /tmp/volume/memoization-key
+                  exit 0
+                fi
+                git_revision_sha="$(git ls-remote ${git_uri} ${git_revision} | cut -f1)" 
+                echo "git_revision_sha=\"$git_revision_sha\"" >> /tmp/volume/memoization-params
+                key="${name}-${git_revision_sha}"
+                echo "${key}" > /tmp/volume/memoization-key
+            volumeMounts:
+              - name: tmp
+                mountPath: /tmp/volume
+            dependencies:
+              - prepare-memoization-params
+    - name: delete-memoization-configmap
+      resource:
+        action: delete
+        manifest: |
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: build-okd
+            namespace: argo-workflows
+            # TODO: is there a way for this configmap to land in the same namespace as the workflow?
+    - name: package-release
+      inputs:
+        parameters:
+          - default: quay.io/<org>/okd-release-argo:4.13.0-0.okd-fcos-bfs
+            name: release-image-location
+          - default: quay.io/<org>/okd-release-argo
+            name: release-mirror-location
+      containerSet:
+        containers:
+          - args:
+              - |
+                #!/bin/bash
+                set -ex
+                oc registry login -a /var/run/credentials/.dockerconfigjson
+                oc adm release new \
+                  --registry-config=/var/run/credentials/.dockerconfigjson \
+                  --from-image-stream release \
+                  --insecure=true \
+                  --mirror {{inputs.parameters.release-mirror-location}} \
+                  --to-image {{inputs.parameters.release-image-location}} \
+                  --name=$(echo "{{inputs.parameters.release-image-location}}" | cut -d: -f2) \
+                  --keep-manifest-list=true
+                  --allow-missing-images=true # TODO remove
+            command:
+              - bash
+              - -c
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli
+            name: package-release
+            volumeMounts:
+              - mountPath: /var/run/credentials
+                name: registry-robot-token
+      volumes:
+        - name: credentials
+          secret:
+            secretName: '{{workflow.parameters.registry-credentials-secret-ref}}'

--- a/argo-workflows/okd-workflows/kustomization.yaml
+++ b/argo-workflows/okd-workflows/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - 15-rbac.yaml
+  - 30-build-workflow-template.yaml
+  - 40-build-from-scratch.yaml
+

--- a/argo-workflows/operator-deployment/00-namespace.yaml
+++ b/argo-workflows/operator-deployment/00-namespace.yaml
@@ -1,0 +1,4 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: argo-workflows

--- a/argo-workflows/operator-deployment/10-patch-workflow-controller-configmap.yaml
+++ b/argo-workflows/operator-deployment/10-patch-workflow-controller-configmap.yaml
@@ -1,0 +1,407 @@
+# This file describes the config settings available in the workflow controller configmap
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: workflow-controller-configmap
+data:
+  executor: |
+    imagePullPolicy: IfNotPresent
+    # TODO: Temp until we can upgrade to a new version 
+    # with the fix for https://github.com/argoproj/argo-workflows/issues/10538
+    # image: quay.io/argoproj/argoexec:latest
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: true
+  mainContainer: |
+    imagePullPolicy: IfNotPresent
+    # TODO: Temp until we can upgrade to a new version 
+    # with the fix for https://github.com/argoproj/argo-workflows/issues/10538
+    # image: quay.io/argoproj/argoexec:latest
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: true
+  workflowDefaults: |
+    spec:
+      serviceAccountName: workflows
+      securityContext:
+        runAsNonRoot: true
+
+  ## instanceID is a label selector to limit the controller's watch to a specific instance. It
+  ## contains an arbitrary value that is carried forward into its pod labels, under the key
+  ## workflows.argoproj.io/controller-instanceid, for the purposes of workflow segregation. This
+  ## enables a controller to only receive workflow and pod events that it is interested about,
+  ## in order to support multiple controllers in a single cluster, and ultimately allows the
+  ## controller itself to be bundled as part of a higher level application. If omitted, the
+  ## controller watches workflows and pods that *are not* labeled with an instance id.
+  #instanceID: my-ci-controller
+
+  ## Parallelism limits the max total parallel workflows that can execute at the same time
+  ## (available since Argo v2.3). Controller must be restarted to take effect.
+  #parallelism: 10
+
+  ## Limit the maximum number of incomplete workflows in a namespace.
+  ## Intended for cluster installs that are multi-tenancy environments, to prevent too many workflows in one
+  ## namespace impacting others.
+  ## >= v3.2
+  #namespaceParallelism: "10"
+
+  ## Globally limits the rate at which pods are created.
+  ## This is intended to mitigate flooding of the Kubernetes API server by workflows with a large amount of
+  ## parallel nodes.
+  #resourceRateLimit: |
+  #  limit: 10
+  #  burst: 1
+
+  ## Whether or not to emit events on node completion. These can take a up a lot of space in
+  ## k8s (typically etcd) resulting in errors when trying to create new events:
+  ## "Unable to create audit event: etcdserver: mvcc: database space exceeded"
+  ## This config item allows you to disable this.
+  ## (since v2.9)
+  #nodeEvents: |
+  #  enabled: true
+
+  ## uncomment following lines if workflow controller runs in a different k8s cluster with the
+  ## workflow workloads, or needs to communicate with the k8s apiserver using an out-of-cluster
+  ## kubeconfig secret
+  ## kubeConfig:
+  ##   # name of the kubeconfig secret, may not be empty when kubeConfig specified
+  ##   secretName: kubeconfig-secret
+  ##   # key of the kubeconfig secret, may not be empty when kubeConfig specified
+  ##   secretKey: kubeconfig
+  ##   # mounting path of the kubeconfig secret, default to /kube/config
+  ##   mountPath: /kubeconfig/mount/path
+  ##   # volume name when mounting the secret, default to kubeconfig
+  ##   volumeName: kube-config-volume
+
+  #links: |
+  #  # Adds a button to the workflow page. E.g. linking to you logging facility.
+  #  - name: Example Workflow Link
+  #    scope: workflow
+  #    url: http://logging-facility?namespace=${metadata.namespace}&workflowName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}
+  #  # Adds a button next to the pod.  E.g. linking to you logging facility but for the pod only.
+  #  - name: Example Pod Link
+  #    scope: pod
+  #    url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}
+  #  - name: Pod Logs
+  #    scope: pod-logs
+  #    url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}
+  #  - name: Event Source Logs
+  #    scope: event-source-logs
+  #    url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}
+  #  - name: Sensor Logs
+  #    scope: sensor-logs
+  #    url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}
+  #  # Adds a button to the bottom right of every page to link to your organisation help or chat.
+  #  - name: Get help
+  #    scope: chat
+  #    url: http://my-chat
+  #  # Adds a button to the top of workflow view to navigate to customized views.
+  #  - name: Completed Workflows
+  #    scope: workflow-list
+  #    url: http://workflows?label=workflows.argoproj.io/completed=true
+
+  ## uncomment following lines if you want to change navigation bar background color
+  ## navColor: red
+
+  ## artifactRepository defines the default location to be used as the artifact repository for
+  ## container artifacts.
+  #artifactRepository: |
+  #  # archiveLogs will archive the main container logs as an artifact
+  #  archiveLogs: true
+
+  #  s3:
+  #    # Use the corresponding endpoint depending on your S3 provider:
+  #    #   AWS: s3.amazonaws.com
+  #    #   GCS: storage.googleapis.com
+  #    #   Minio: my-minio-endpoint.default:9000
+  #    endpoint: s3.amazonaws.com
+  #    bucket: my-bucket
+  #    region: us-west-2
+  #    # insecure will disable TLS. Primarily used for minio installs not configured with TLS
+  #    insecure: false
+  #    # keyFormat is a format pattern to define how artifacts will be organized in a bucket.
+  #    # It can reference workflow metadata variables such as workflow.namespace, workflow.name,
+  #    # pod.name. Can also use strftime formating of workflow.creationTimestamp so that workflow
+  #    # artifacts can be organized by date. If omitted, will use `{{workflow.name}}/{{pod.name}}`,
+  #    # which has potential for have collisions.
+  #    # The following example pattern organizes workflow artifacts under a "my-artifacts" sub dir,
+  #    # then sub dirs for year, month, date and finally workflow name and pod.
+  #    # e.g.: my-artifacts/2018/08/23/my-workflow-abc123/my-workflow-abc123-1234567890
+  #    keyFormat: "my-artifacts\
+  #      /{{workflow.creationTimestamp.Y}}\
+  #      /{{workflow.creationTimestamp.m}}\
+  #      /{{workflow.creationTimestamp.d}}\
+  #      /{{workflow.name}}\
+  #      /{{pod.name}}"
+  #    # The actual secret object (in this example my-s3-credentials), should be created in every
+  #    # namespace where a workflow needs to store its artifacts to S3. If omitted,
+  #    # attempts to use IAM role to access the bucket (instead of accessKey/secretKey).
+  #    accessKeySecret:
+  #      name: my-s3-credentials
+  #      key: accessKey
+  #    secretKeySecret:
+  #      name: my-s3-credentials
+  #      key: secretKey
+  #    # If this is set to true, argo workflows will use AWS SDK default credentials provider chain. This will allow things like
+  #    # IRSA and any of the authentication methods that the golang SDK uses in it's default chain.
+  #    # If you are using IRSA on AWS, and set this option to true, you will also need to modify Argo-Server Deployment with
+  #    # `spec.template.spec.securityContext.fsGroup: 65534` configuration. This is required for IRSA to be able to access
+  #    # `/var/run/secrets/eks.amazonaws.com/serviceaccount/token` file, and authenticate with AWS.
+  #    useSDKCreds: false
+
+  #    encryptionOptions:
+  #      # If this is set to true, SSE-S3 encryption will be used to store objects
+  #      # unless kmsKeyId or serverSideCustomerKeySecret is set
+  #      enableEncryption: false
+  #      # A valid kms key id. If this value is set, the object stored in s3 will be encrypted with SSE-KMS
+  #      # Note: You cannot set both kmsKeyId and serverSideCustomerKeySecret
+  #      # kmsKeyId: ''
+  #      # Allows you to set a json blob of simple key value pairs. See
+  #      # https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context
+  #      # for more information
+  #      # kmsEncryptionContext: ''
+  #      # The actual secret object (in this example my-s3-credentials),
+  #      # should be created when using a custom secret to encrypt objects in using SSE-C
+  #      # Note: You cannot set both kmsKeyId and serverSideCustomerKeySecret
+  #      # serverSideCustomerKeySecret:
+  #      #  name: my-s3-credentials
+  #      #  key: secretKey
+
+
+
+  ## Specifies the container runtime interface to use (default: emissary)
+  ## must be one of: docker, kubelet, k8sapi, pns, emissary
+  ## It has lower precedence than either `--container-runtime-executor` and `containerRuntimeExecutors`.
+  ## (removed in v3.4)
+  #containerRuntimeExecutor: emissary
+
+  ## Specifies the executor to use.
+  ##
+  ## You can use this to:
+  ## * Tailor your executor based on your preference for security or performance.
+  ## * Test out an executor without committing yourself to use it for every workflow.
+  ##
+  ## To find out which executor was actually use, see the `wait` container logs.
+  ##
+  ## The list is in order of precedence; the first matching executor is used.
+  ## This has precedence over `containerRuntimeExecutor`.
+  ## (removed in v3.4)
+  #containerRuntimeExecutors: |
+  #  - name: emissary
+  #    selector:
+  #      matchLabels:
+  #        workflows.argoproj.io/container-runtime-executor: emissary
+  #  - name: pns
+  #    selector:
+  #      matchLabels:
+  #        workflows.argoproj.io/container-runtime-executor: pns
+
+  ## Specifies the location of docker.sock on the host for docker executor (default: /var/run/docker.sock)
+  ## (available v2.4-v3.3)
+  #dockerSockPath: /var/someplace/else/docker.sock
+
+  ## kubelet port when using kubelet executor (default: 10250) (kubelet executor will be deprecated use emissary instead)
+  ## (removed in v3.4)
+  #kubeletPort: 10250
+
+  ## disable the TLS verification of the kubelet executor (default: false)
+  ## (removed in v3.4)
+  #kubeletInsecure: false
+
+  ## The command/args for each image, needed when the command is not specified and the emissary executor is used.
+  ## https://argoproj.github.io/argo-workflows/workflow-executors/#emissary-emissary
+  #images: |
+  #  argoproj/argosay:v2:
+  #    cmd: [/argosay]
+  #  docker/whalesay:latest:
+  #    cmd: [/bin/bash]
+
+  ## Defaults for main containers. These can be overridden by the template.
+  ## <= v3.3 only `resources` are supported.
+  ## >= v3.4 all fields are supported, including security context.
+  #mainContainer: |
+  #  imagePullPolicy: IfNotPresent
+  #  resources:
+  #    requests:
+  #      cpu: 0.1
+  #      memory: 64Mi
+  #    limits:
+  #      cpu: 0.5
+  #      memory: 512Mi
+  #  securityContext:
+  #    allowPrivilegeEscalation: false
+  #    capabilities:
+  #      drop:
+  #      - ALL
+  #    readOnlyRootFilesystem: true
+  #    runAsNonRoot: true
+  #    runAsUser: 1000
+
+  ## executor controls how the init and wait container should be customized
+  ## (available since Argo v2.3)
+  #executor: |
+  #  imagePullPolicy: IfNotPresent
+  #  resources:
+  #    requests:
+  #      cpu: 0.1
+  #      memory: 64Mi
+  #    limits:
+  #      cpu: 0.5
+  #      memory: 512Mi
+  #  # args & env allows command line arguments and environment variables to be appended to the
+  #  # executor container and is mainly used for development/debugging purposes.
+  #  args:
+  #  - --loglevel
+  #  - debug
+  #  - --gloglevel
+  #  - "6"
+  #  env:
+  #  # ARGO_TRACE enables some tracing information for debugging purposes. Currently it enables
+  #  # logging of S3 request/response payloads (including auth headers)
+  #  - name: ARGO_TRACE
+  #    value: "1"
+
+  ## metricsConfig controls the path and port for prometheus metrics. Metrics are enabled and emitted on localhost:9090/metrics
+  ## by default.
+  #metricsConfig: |
+  #  # Enabled controls metric emission. Default is true, set "enabled: false" to turn off
+  #  enabled: true
+  #  # Path is the path where metrics are emitted. Must start with a "/". Default is "/metrics"
+  #  path: /metrics
+  #  # Port is the port where metrics are emitted. Default is "9090"
+  #  port: 8080
+  #  # MetricsTTL sets how often custom metrics are cleared from memory. Default is "0", metrics are never cleared
+  #  metricsTTL: "10m"
+  #  # IgnoreErrors is a flag that instructs prometheus to ignore metric emission errors. Default is "false"
+  #  ignoreErrors: false
+  #  # Use a self-signed cert for TLS, default false
+  #  secure: false
+
+  #  # DEPRECATED: Legacy metrics are now removed, this field is ignored
+  #  disableLegacy: false
+
+  ## telemetryConfig controls the path and port for prometheus telemetry. Telemetry is enabled and emitted in the same endpoint
+  ## as metrics by default, but can be overridden using this config.
+  #telemetryConfig: |
+  #  enabled: true
+  #  path: /telemetry
+  #  port: 8080
+  #  secure: true  # Use a self-signed cert for TLS, default false
+
+  ## enable persistence using postgres
+  #persistence: |
+  #  connectionPool:
+  #    maxIdleConns: 100
+  #    maxOpenConns: 0
+  #    connMaxLifetime: 0s # 0 means connections don't have a max lifetime
+  #  #  if true node status is only saved to the persistence DB to avoid the 1MB limit in etcd
+  #  nodeStatusOffLoad: false
+  #  # save completed workloads to the workflow archive
+  #  archive: false
+  #  # the number of days to keep archived workflows (the default is forever)
+  #  archiveTTL: 180d
+  #  # skip database migration if needed.
+  #  # skipMigration: true
+
+  #  # LabelSelector determines the workflow that matches with the matchlabels or matchrequirements, will be archived.
+  #  # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  #  archiveLabelSelector:
+  #    matchLabels:
+  #      workflows.argoproj.io/archive-strategy: "always"
+
+  #  # Optional name of the cluster I'm running in. This must be unique for your cluster.
+  #  clusterName: default
+  #  postgresql:
+  #    host: localhost
+  #    port: 5432
+  #    database: postgres
+  #    tableName: argo_workflows
+  #    # the database secrets must be in the same namespace of the controller
+  #    userNameSecret:
+  #      name: argo-postgres-config
+  #      key: username
+  #    passwordSecret:
+  #      name: argo-postgres-config
+  #      key: password
+  #    ssl: true
+  #    # sslMode must be one of: disable, require, verify-ca, verify-full
+  #    # you can find more information about those ssl options here: https://godoc.org/github.com/lib/pq
+  #    sslMode: require
+
+  #  # Optional config for mysql:
+  #  # mysql:
+  #  #   host: localhost
+  #  #   port: 3306
+  #  #   database: argo
+  #  #   tableName: argo_workflows
+  #  #   userNameSecret:
+  #  #     name: argo-mysql-config
+  #  #     key: username
+  #  #   passwordSecret:
+  #  #     name: argo-mysql-config
+  #  #     key: password
+
+  ## Default values that will apply to all Workflows from this controller, unless overridden on the Workflow-level
+  ## See more: docs/default-workflow-specs.md
+  #workflowDefaults: |
+  #  metadata:
+  #    annotations:
+  #      argo: workflows
+  #    labels:
+  #      foo: bar
+  #  spec:
+
+  #    ttlStrategy:
+  #      secondsAfterSuccess: 5
+  #    parallelism: 3
+
+  ## SSO Configuration for the Argo server.
+  ## You must also start argo server with `--auth-mode sso`.
+  ## https://argoproj.github.io/argo-workflows/argo-server-auth-mode/
+  #sso: |
+  #  # This is the root URL of the OIDC provider (required).
+  #  issuer: https://issuer.root.url/
+  #  # Some OIDC providers have alternate root URLs that can be included. These should be reviewed carefully. (optional)
+  #  issuerAlias: https://altissuer.root.url
+  #  # This defines how long your login is valid for (in hours). (optional)
+  #  # If omitted, defaults to 10h. Example below is 10 days.
+  #  sessionExpiry: 240h
+  #  # This is name of the secret and the key in it that contain OIDC client
+  #  # ID issued to the application by the provider (required).
+  #  clientId:
+  #    name: client-id-secret
+  #    key: client-id-key
+  #  # This is name of the secret and the key in it that contain OIDC client
+  #  # secret issued to the application by the provider (required).
+  #  clientSecret:
+  #    name: client-secret-secret
+  #    key: client-secret-key
+  #  # This is the redirect URL supplied to the provider (optional). It must
+  #  # be in the form <argo-server-root-url>/oauth2/callback. It must be
+  #  # browser-accessible. If omitted, will be automatically generated.
+  #  redirectUrl: https://argo-server/oauth2/callback
+  #  # Additional scopes to request. Typically needed for SSO RBAC. >= v2.12
+  #  scopes:
+  #   - groups
+  #   - email
+  #  # RBAC Config. >= v2.12
+  #  rbac:
+  #    enabled: false
+  #  # Skip TLS verify, not recommended in production environments. Useful for testing purposes. >= v3.2.4
+  #  insecureSkipVerify: false
+
+  ## workflowRestrictions restricts the Workflows that the controller will process.
+  ## Current options:
+  ##   Strict: Only Workflows using "workflowTemplateRef" will be processed. This allows the administrator of the controller
+  ##     to set a "library" of templates that may be run by its operator, limiting arbitrary Workflow execution.
+  ##   Secure: Only Workflows using "workflowTemplateRef" will be processed and the controller will enforce
+  ##     that the WorkflowTemplate that is referenced hasn't changed between operations. If you want to make sure the operator of the
+  ##     Workflow cannot run an arbitrary Workflow, use this option.
+  #workflowRestrictions: |
+  #  templateReferencing: Strict

--- a/argo-workflows/operator-deployment/15-rbac.yaml
+++ b/argo-workflows/operator-deployment/15-rbac.yaml
@@ -1,0 +1,34 @@
+kind: List
+apiVersion: v1
+items:
+  # Needed to allow the memoization feature work with configmaps
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      name: edit-config-map
+      namespace: argo-workflows
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - configmaps
+        verbs:
+          - get
+          - list
+          - create
+          - update
+          - patch
+          - delete
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: argo-edit-config-map
+      namespace: argo-workflows
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: edit-config-map
+    subjects:
+      - kind: ServiceAccount
+        name: argo
+        namespace: argo-workflows

--- a/argo-workflows/operator-deployment/20-service-ca-cm.yaml
+++ b/argo-workflows/operator-deployment/20-service-ca-cm.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  name: service-ca
+  namespace: argo-workflows

--- a/argo-workflows/operator-deployment/25-oauth-deployment.yaml
+++ b/argo-workflows/operator-deployment/25-oauth-deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oauth-proxy
+  namespace: argo-workflows
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: oauth-proxy
+  template:
+    metadata:
+      labels:
+        app: oauth-proxy
+    spec:
+      containers:
+        - args:
+            - --provider=openshift
+            - --https-address=:8083
+            - --http-address=
+            - --tls-cert=/tls/tls.crt
+            - --tls-key=/tls/tls.key
+            - --ssl-insecure-skip-verify=true
+            - --client-id=argo-workflows-oauth
+            - --client-secret=argo-oauth-proxy-secret
+            - --openshift-ca=/etc/pki/tls/cert.pem
+            - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            - --openshift-ca=/service-ca/service-ca.crt
+            - --scope=user:full user:info user:check-access user:list-projects
+            - --cookie-secret-file=/secret/session-secret
+            - --cookie-secure=true
+            - --upstream=http://argo-server:2746
+            - --redirect-url=https://$CHANGE_ME/oauth2/callback/ # <<< TODO
+            - --email-domain=*
+          image: image-registry.openshift-image-registry.svc:5000/openshift/oauth-proxy:v4.4
+          imagePullPolicy: Always
+          name: oauth-proxy
+          ports:
+            - containerPort: 8083
+              name: https
+              protocol: TCP
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 10m
+              memory: 20Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /service-ca
+              name: service-ca
+              readOnly: true
+            - mountPath: /secret
+              name: argo-workflows-oauth-secret
+              readOnly: true
+            - mountPath: /tls
+              name: oauth-proxy-tls-secret
+              readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - configMap:
+            defaultMode: 420
+            name: service-ca
+          name: service-ca
+        - name: oauth-proxy-tls-secret
+          secret:
+            defaultMode: 420
+            secretName: oauth-proxy-tls-secret
+        - name: argo-workflows-oauth-secret
+          secret:
+            defaultMode: 420
+            secretName: argo-workflows-oauth-secret

--- a/argo-workflows/operator-deployment/25-oauth-deployment.yaml
+++ b/argo-workflows/operator-deployment/25-oauth-deployment.yaml
@@ -31,7 +31,6 @@ spec:
             - --cookie-secret-file=/secret/session-secret
             - --cookie-secure=true
             - --upstream=http://argo-server:2746
-            - --redirect-url=https://$CHANGE_ME/oauth2/callback/ # <<< TODO
             - --email-domain=*
           image: image-registry.openshift-image-registry.svc:5000/openshift/oauth-proxy:v4.4
           imagePullPolicy: Always

--- a/argo-workflows/operator-deployment/25-oauth-service.yaml
+++ b/argo-workflows/operator-deployment/25-oauth-service.yaml
@@ -1,0 +1,15 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: oauth-proxy
+  namespace: argo-workflows
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: oauth-proxy-tls-secret
+spec:
+  type: ClusterIP
+  ports:
+  - name: ssl
+    port: 443
+    targetPort: 8083
+  selector:
+    app: oauth-proxy

--- a/argo-workflows/operator-deployment/30-route.yaml
+++ b/argo-workflows/operator-deployment/30-route.yaml
@@ -1,0 +1,17 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: argo-server
+  namespace: argo-workflows
+spec:
+  host: ""
+  to:
+    kind: Service
+    name: oauth-proxy
+    weight: 100
+  port:
+    targetPort: ssl
+  tls:
+    termination: passthrough
+    insecureEdgeTerminationPolicy: None
+  wildcardPolicy: None

--- a/argo-workflows/operator-deployment/50-oauth-client.yaml
+++ b/argo-workflows/operator-deployment/50-oauth-client.yaml
@@ -1,0 +1,8 @@
+kind: OAuthClient
+apiVersion: oauth.openshift.io/v1
+metadata:
+  name: argo-workflows-oauth
+  namespace: argo-workflows
+secret: "argo-oauth-proxy-secret"
+redirectURIs: []
+grantMethod: prompt

--- a/argo-workflows/operator-deployment/README.md
+++ b/argo-workflows/operator-deployment/README.md
@@ -1,0 +1,7 @@
+### Argo workflows on OKD
+
+The manifests in this folder allow to deploy argo workflows, and need yet further works, like:
+
+- TLS certs generation and configuration
+- Use SSO mode for authentication?
+-  ...

--- a/argo-workflows/operator-deployment/dotenv.example
+++ b/argo-workflows/operator-deployment/dotenv.example
@@ -1,0 +1,1 @@
+session-secret=OvaKjiPD1W1bnhpddBgc5JnvNDxiyIfGyM8DUjy7gbl

--- a/argo-workflows/operator-deployment/kustomization.yaml
+++ b/argo-workflows/operator-deployment/kustomization.yaml
@@ -1,0 +1,64 @@
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: argo-workflows
+
+resources:
+  - 00-namespace.yaml
+  - https://github.com/argoproj/argo-workflows/releases/download/v3.4.8/install.yaml
+  - 15-rbac.yaml
+  - 20-service-ca-cm.yaml
+  - 25-oauth-deployment.yaml
+  - 25-oauth-service.yaml
+  - 30-route.yaml
+  - 50-oauth-client.yaml
+# For local testing
+patches:
+  - target:
+      name: argo-server
+      kind: Deployment
+    patch: |
+      - op: replace
+        path: "/spec/template/spec/containers/0/readinessProbe/httpGet/scheme"
+        value: HTTP
+      
+      - op: replace
+        path: "/spec/template/spec/containers/0/args"
+        value:
+        - "server"
+        - "--auth-mode=server"
+        - "--access-control-allow-origin=*"
+        - "--secure=false"
+        - "--verbose"
+  - target:
+      name: workflow-controller-configmap
+      kind: ConfigMap
+    path: 10-patch-workflow-controller-configmap.yaml
+  - target:
+      name: argo-workflows-oauth
+      kind: OAuthClient
+    patch: |-
+      - op: add
+        path: "/redirectURIs/-"
+        value: "${ARGO_FINAL_URL}"
+        # TODO ^ find a better way to push the route hostname into the OAuthClient redirectURIs list
+replacements:
+  - source:
+      kind: Deployment
+      name: argo-server
+      fieldPath: metadata.namespace
+    targets:
+      - select:
+          group: rbac.authorization.k8s.io
+          version: v1
+          kind: RoleBinding
+          name: argo-edit-config-map
+        fieldPaths:
+          # All subjects in the RoleBinding
+          - subjects[*].namespace
+
+secretGenerator:
+  - name: argo-workflows-oauth-secret
+    envs:
+      - .env
+

--- a/argo-workflows/operator-deployment/kustomization.yaml
+++ b/argo-workflows/operator-deployment/kustomization.yaml
@@ -15,6 +15,15 @@ resources:
 # For local testing
 patches:
   - target:
+      name: oauth-proxy
+      kind: Deployment
+    patch: |
+      - op: add
+        path: "/spec/template/spec/containers/0/args/-"
+        value:
+          '--redirect-url=${ARGO_FINAL_URL}/oauth2/callback/'
+      # TODO ^ find a better way to push the route hostname into the oauth-proxy redirect-url
+  - target:
       name: argo-server
       kind: Deployment
     patch: |

--- a/buildconfigs/02-additional-imagestream.yaml
+++ b/buildconfigs/02-additional-imagestream.yaml
@@ -7,16 +7,18 @@ spec:
     local: true
   tags:
     - name: centos9
-      annotations: null
       from:
         kind: DockerImage
         name: 'quay.io/centos/centos:stream9'
       referencePolicy:
         type: Local
+      importPolicy:
+        importMode: PreserveOriginal # Needs OKD 4.13
     - name: fedora36
-      annotations: null
       from:
         kind: DockerImage
         name: 'quay.io/fedora/fedora:36'
       referencePolicy:
         type: Local
+      importPolicy:
+        importMode: PreserveOriginal # Needs OKD 4.13

--- a/variants/fcos-multiarch/10-service-account.yaml
+++ b/variants/fcos-multiarch/10-service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: workflows

--- a/variants/fcos-multiarch/kustomization.yaml
+++ b/variants/fcos-multiarch/kustomization.yaml
@@ -1,0 +1,40 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: okd-fcos
+
+resources:
+  - ../../argo-workflows/okd-workflows
+  - ../../buildconfigs
+  - ./10-service-account.yaml
+
+patches:
+  - patch: |-
+      apiVersion: build.openshift.io/v1
+      kind: BuildConfig
+      metadata:
+        name: not-used
+        labels:
+          change-build-arg-tags: ""
+      spec:
+        strategy:
+          dockerStrategy:
+            buildArgs:
+              - name: "TAGS"
+                value: "fcos"
+    target:
+      labelSelector: "change-build-arg-tags==true"
+      kind: BuildConfig
+  - patch: |-
+      - op: add
+        path: "/spec/tags/-"
+        value:
+          name: fedora-coreos
+          from:
+            kind: DockerImage
+            name: quay.io/fedora/fedora-coreos:next-devel
+          referencePolicy:
+            type: Source
+    target:
+      kind: ImageStream
+      name: tools

--- a/variants/scos/kustomization.yaml
+++ b/variants/scos/kustomization.yaml
@@ -34,6 +34,7 @@ patches:
             type: Local
           importPolicy:
             scheduled: true
+            importMode: PreserveOriginal # Needs OKD 4.13
     target:
       kind: ImageStream
       name: release
@@ -47,6 +48,8 @@ patches:
             name: release:centos-stream-coreos-9
           referencePolicy:
             type: Local
+          importPolicy:
+            importMode: PreserveOriginal # Needs OKD 4.13 (and an actual manifest list scos image to import)
     target:
       kind: ImageStream
       name: release


### PR DESCRIPTION
This PR aims to provide an(other) alternative to the build system towards a multi-arch okd build.

As we discussed, this is based on Argo Workflows, which seems promising. However, it currently relies on the Builds v1 APIs and the internal registry (therefore depending on an okd/ocp 4.13, multi-arch, cluster).

The manifests in the argo-workflows folder provide:
1. installation for the argo-workflow operator
2. The ClusterWorkflowTemplates and the related objects to 
  a. create 1 build per architecture from a build config and compose a manifest list in the okd internal registry;
  b. run a build-from-scratch workflow equivalent to the current build-from-scratch Tekton pipeline, but multi-arch.

The build-from-scratch workflow also uses:
- memoization caching to avoid rebuilding images already built (especially useful for debugging purposes)
- garbage collection via success/failure ttls
- consider the os-image an input parameter rather than an image stream tag provided externally
- do not implement release packaging and publishing steps yet



cc @LorbusChris @jeffdyoung @Prashanth684
